### PR TITLE
Fix add_to_list

### DIFF
--- a/bot/commands.py
+++ b/bot/commands.py
@@ -8,7 +8,7 @@ async def add_to_list(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     strings = update.message.text.lower().split()
 
-    if len(strings) >= 3:
+    if len(strings) >= 3 and len(strings) % 2 != 0:
         strings.remove('/addtolist')
 
         chat_id = update.message.chat_id


### PR DESCRIPTION
Внутри функции add_to_list проверяем, что аргументов достаточно для добавления "Время Данные", но не было исключений для нечетных аргументов типо "Время Данные Данные"
Исправил такую возможность (〃￣︶￣)人(￣︶￣〃)
